### PR TITLE
Change the padding value rather than zero

### DIFF
--- a/kaldi-native-fbank/python/tests/test_online_whisper_fbank.py
+++ b/kaldi-native-fbank/python/tests/test_online_whisper_fbank.py
@@ -35,7 +35,7 @@ def test():
     log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
     mel = (log_spec + 4.0) / 4.0
     target = 3000
-    mel = torch.nn.functional.pad(mel, (0, 0, 0, target - mel.shape[0]), "constant", 0)
+    mel = torch.nn.functional.pad(mel, (0, 0, 0, target - mel.shape[0]), "constant", mel[0].min().item())
     mel = mel.t().unsqueeze(0)
     print(mel.shape)
 


### PR DESCRIPTION
Using zero as the padding value destroys the Whisper generation results. Change to the minimum value in the first frame.