### PR TITLE
CMake: correct MAKE_DIRECTORY invocation

### DIFF
--- a/kaldi-native-fbank/csrc/CMakeLists.txt
+++ b/kaldi-native-fbank/csrc/CMakeLists.txt
@@ -88,7 +88,6 @@ if(KALDI_NATIVE_FBANK_BUILD_TESTS)
 endif()
 
 file(MAKE_DIRECTORY
-  DESTINATION
     ${PROJECT_BINARY_DIR}/include/kaldi-native-fbank/csrc
 )
 file(GLOB_RECURSE all_headers *.h)


### PR DESCRIPTION
CMake `MAKE_DIRECTORY` [(docs)](https://cmake.org/cmake/help/latest/command/file.html#make-directory) does not have a `DESTINATION` option - the current invocation results in the (attempted) creation of a bogus 'DESTINATION' directory within the source tree.

```
$ fd DESTINATION
sherpa-onnx-1.12.14/build/_deps/kaldi_native_fbank-src/kaldi-native-fbank/csrc/DESTINATION/
```

It prevents sherpa-onnx from building with Nix - as source trees are immutable in Nix the mkdir will fail and break the build.